### PR TITLE
feat: static site previews

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -1,0 +1,37 @@
+name: Build Hugo site from PR
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.141.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+
+      - name: Build site
+        uses: omsf/static-site-tools/build/hugo@main
+        with:
+          base-url: ""
+
+      - name: Make artifact
+        shell: bash
+        run: tar czf site.tar.gz public
+
+      - name: Upload build artifact
+        if: ${{ github.event_name != 'schedule' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-build
+          path: site.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/cleanup-cloudflare.yaml
+++ b/.github/workflows/cleanup-cloudflare.yaml
@@ -1,0 +1,16 @@
+name: Cleanup Hugo site staging
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup-staging:
+    if: ${{ github.repository == vars.MAIN_REPO }}
+    uses: omsf/static-site-tools/.github/workflows/cleanup-cloudflare.yaml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      project_name: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/stage-cloudflare.yaml
+++ b/.github/workflows/stage-cloudflare.yaml
@@ -1,0 +1,41 @@
+name: Upload Hugo site to staging
+
+on:
+  workflow_run:
+    workflows: ["Build Hugo site from PR"]
+    types:
+      - completed
+
+jobs:
+  get-metadata:
+    if: ${{ github.repository == vars.MAIN_REPO }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr-metadata.outputs.pr-number }}
+      pr_headsha: ${{ steps.pr-metadata.outputs.pr-headsha }}
+
+    steps:
+      - name: Get PR metadata from action
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        id: pr-metadata
+        uses: omsf/static-site-tools/pr-info-from-workflow-run@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  stage:
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.repository == vars.MAIN_REPO) }}
+    needs: get-metadata
+    uses: omsf/static-site-tools/.github/workflows/stage-cloudflare.yaml@main
+    permissions:
+      statuses: write
+      pull-requests: write
+    with:
+      run-id: ${{ github.event.workflow_run.id }}
+      pr-number: ${{ fromJSON(needs.get-metadata.outputs.pr_number) }}
+      pr-headsha: ${{ needs.get-metadata.outputs.pr_headsha }}
+      project-name: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+      html-dir: ${{ vars.HUGO_OUTPUT_DIR || 'public' }}
+      label: Hugo site
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenADMET website
 
-This repository contains the source code for the OpenADMET website, which is built using [Hugo](https://gohugo.io/) and hosted on Github Pages.
+This repository contains the source code for the OpenADMET website, which is built using [Hugo](https://gohugo.io/) and can be deployed to both GitHub Pages. We are using Cloudflare Pages to handle preview deployments of changes.
 
 
 ## Preview the website locally
@@ -21,11 +21,20 @@ Web Server is available at //localhost:1313/ (bind address 127.0.0.1)
 
 ## Deploying
 
+### GitHub Pages (Current)
 Deploying is handled by a Github actions (see the `.github/workflows/gh-pages.yml` file). Commits/PRs into the `main` branch will trigger a new build. Once built, the action will push the content to the `gh-pages` branch, which the website is now served from.
 
+### Cloudflare Pages (Optional)
+The repository is also configured for Cloudflare Pages deployment with automatic PR previews. This provides:
+- **PR Previews**: Every pull request gets a unique preview URL for testing changes
+- **Cleanup**: Automatic removal of old preview deployments when PRs are closed
 
+#### Cloudflare Workflows
+- `build-pr.yaml` - Builds Hugo site for PR previews
+- `stage-cloudflare.yaml` - Deploys PR previews to Cloudflare staging
+- `cleanup-cloudflare.yaml` - Cleans up old preview deployments
 
-## Developer Guide 
+## Developer Guide
 
 ### Adding new members
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenADMET website
 
-This repository contains the source code for the OpenADMET website, which is built using [Hugo](https://gohugo.io/) and can be deployed to both GitHub Pages. We are using Cloudflare Pages to handle preview deployments of changes.
+This repository contains the source code for the OpenADMET website, which is built using [Hugo](https://gohugo.io/) and is deployed to GitHub Pages. We are using Cloudflare Pages to handle preview deployments of changes.
 
 
 ## Preview the website locally


### PR DESCRIPTION
This pull request introduces GitHub Actions workflows to automate the build, staging, and cleanup processes for Hugo site deployments on Cloudflare Pages. Additionally, the `README.md` file has been updated to reflect these changes. 

### GitHub Actions Workflows for Hugo Site Deployment:

* [`.github/workflows/build-pr.yaml`](diffhunk://#diff-2be6cc0c95fb82543c35ffb24cb00fb0034210d77c8d1a2c855d8ede27456427R1-R37): Adds a workflow to build the Hugo site for pull requests, generate an artifact, and upload it for staging.
* [`.github/workflows/stage-cloudflare.yaml`](diffhunk://#diff-c8679953479618560a08d51779d0c4db5274e430a65d3602da16fb7626dc1ec8R1-R41): Adds a workflow to stage the Hugo site on Cloudflare Pages after successful builds, including PR metadata handling and deployment configurations.
* [`.github/workflows/cleanup-cloudflare.yaml`](diffhunk://#diff-256a11d5a3ba18874134c4a0b5d51e1d19a28bf74ea8a9a81de281238a708a18R1-R16): Adds a workflow to clean up old Cloudflare Pages preview deployments when pull requests are closed.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updates to include details about Cloudflare Pages deployment, PR previews, and associated workflows (`build-pr.yaml`, `stage-cloudflare.yaml`, and `cleanup-cloudflare.yaml`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R35)