### PR TITLE
fix(ci): remove repository condition from Cloudflare workflows

### DIFF
--- a/.github/workflows/cleanup-cloudflare.yaml
+++ b/.github/workflows/cleanup-cloudflare.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   cleanup-staging:
-    if: ${{ github.repository == vars.MAIN_REPO }}
     uses: omsf/static-site-tools/.github/workflows/cleanup-cloudflare.yaml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/stage-cloudflare.yaml
+++ b/.github/workflows/stage-cloudflare.yaml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   get-metadata:
-    if: ${{ github.repository == vars.MAIN_REPO }}
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.pr-metadata.outputs.pr-number }}
@@ -23,7 +22,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   stage:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.repository == vars.MAIN_REPO) }}
+    if: ${{ (github.event.workflow_run.conclusion == 'success') }}
     needs: get-metadata
     uses: omsf/static-site-tools/.github/workflows/stage-cloudflare.yaml@main
     permissions:


### PR DESCRIPTION
Removed the explicit check for MAIN_REPO in both cleanup-cloudflare.yaml and stage-cloudflare.yaml. This update simplifies the condition logic by allowing the workflows to run based on other trigger conditions rather than limiting execution to a specific repository.