### PR TITLE
Auto-update Blog & Videos cards from live feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,50 @@ summary: |
 ```
 
 To set the job to unavailable, modify the `status` tag to `closed`
+
+### Auto-updating Blog & Videos cards
+
+The homepage **Blog** card, the homepage **Videos** card, and the full
+**`/videos`** gallery are not hand-edited. They are generated at build time from
+live feeds, and the nightly build (see `.github/workflows/build-push.yaml`)
+refreshes them automatically — so a new blog post or YouTube video appears on the
+site within a day of publishing, with no code change.
+
+#### How to control what a card says
+
+- **Blog card** text comes from the post's **Excerpt** field in the Ghost editor.
+  If you leave the Excerpt blank, Ghost falls back to scraping the opening
+  sentences of the post, which usually reads poorly on a card. Set the Excerpt
+  when you publish and that becomes the card copy.
+- **Video card** text comes from the video's **description** on YouTube. That
+  description is the single place to edit a video card. A video with no
+  description falls back to generic text, and the build prints a `WARN` naming the
+  video so you know to add one.
+
+#### Where the feed URLs live
+
+All three feeds are configured under `[params]` in `config.toml`
+(`ghostFeed`, `youtubeFeed`, `youtubeChannel`). Point `youtubeFeed` at a
+different channel by changing its `channel_id`.
+
+#### Known behaviors
+
+- **Dates render in UTC.** A video uploaded late in the Pacific evening will show
+  the next day's date. This is not auto-corrected: Hugo ignores the site timezone
+  once a feed timestamp carries a UTC offset, and the alternative (`.Local`) would
+  make a local build and the CI build disagree.
+- **Only the 15 most recent** YouTube uploads are exposed by the feed; older
+  videos drop off `/videos` on their own once newer ones push them past 15.
+- **Every video on the channel appears**, including older workshop recordings,
+  because the page mirrors the channel rather than a curated list.
+
+#### If a feed is down at build time
+
+- **YouTube unreachable or empty** → the build **fails on purpose** (see the
+  `errorf` in `layouts/_default/videos.html`). Because the build fails, the deploy
+  is skipped and the currently live gallery is left untouched, rather than being
+  replaced by an empty page.
+- **Ghost unreachable** → the build **succeeds** and the Blog card falls back to
+  the last-known content baked into `layouts/partials/feeds/ghost-latest.html`.
+  Update that fallback if the most recent post changes and you want the safety net
+  to match.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ site within a day of publishing, with no code change.
   If you leave the Excerpt blank, Ghost falls back to scraping the opening
   sentences of the post, which usually reads poorly on a card. Set the Excerpt
   when you publish and that becomes the card copy.
+  - **External-link posts are a special case.** A few Ghost posts are stubs that
+    redirect to a self-hosted article elsewhere (e.g. "Navigating PXR Chemical
+    Space…" redirects to `openadmet.github.io/octant-pxr-htchem-blogpost/`). These
+    have **no body** in the RSS feed, so there is nothing for Ghost to scrape —
+    if such a post is the newest one, the card preview goes **blank** unless you
+    set an Excerpt. Always set the Excerpt on external-link posts. The redirect
+    itself is unaffected: the card links to the Ghost URL, and Ghost forwards to
+    the self-hosted page, so the "More →" button keeps working as before.
 - **Video card** text comes from the video's **description** on YouTube. That
   description is the single place to edit a video card. A video with no
   description falls back to generic text, and the build prints a `WARN` naming the

--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,11 @@ baseURL = "/"
 languageCode = "en-us"
 title = "OpenAdmet"
 publishDir = "public"
+
+[params]
+  # Feeds fetched at build time to keep the homepage cards and /videos current.
+  # The nightly build in .github/workflows/build-push.yaml re-reads these.
+  ghostFeed = "https://openadmet.ghost.io/rss/"
+  youtubeChannel = "https://www.youtube.com/@OpenADMET"
+  # RSS only exposes the 15 most recent uploads; older videos drop off the page.
+  youtubeFeed = "https://www.youtube.com/feeds/videos.xml?channel_id=UCzwhDb8h5Lgi-AcT4vccS_Q"

--- a/layouts/_default/videos.html
+++ b/layouts/_default/videos.html
@@ -109,118 +109,35 @@
             </div>
         </div>
 
+        {{ $videos := partial "feeds/youtube-videos.html" . }}
+        {{ if not $videos }}
+          {{ errorf "No videos returned from the YouTube feed (%s). Failing the build so the live gallery is left untouched rather than replaced with an empty one." site.Params.youtubeFeed }}
+        {{ end }}
+
         <div class="row g-4">
+            {{ range $videos }}
             <div class="col-md-6 col-xl-4">
                 <div class="card h-100 border-0 shadow-sm rounded-4">
                     <div class="card-body d-flex flex-column p-4">
-                        <div class="text-muted small mb-2">April 29, 2026</div>
-                        <h5 class="card-title fw-bold mb-3">Andrew Ligeralde, PhareBio — QSAR Modeling for Property Prediction and Generative Design</h5>
-                        <a href="https://www.youtube.com/watch?v=c_MhLscr9Lw" target="_blank">
-                            <img src="https://img.youtube.com/vi/c_MhLscr9Lw/hqdefault.jpg" class="img-fluid rounded-3 mb-3" alt="Andrew Ligeralde thumbnail" style="object-fit: cover; width: 100%; height: 200px;">
+                        <div class="text-muted small mb-2">{{ .date }}</div>
+                        <h5 class="card-title fw-bold mb-3">{{ .title }}</h5>
+                        <a href="{{ .url }}" target="_blank">
+                            <img src="{{ .thumb }}" class="img-fluid rounded-3 mb-3" alt="{{ .title }} thumbnail" style="object-fit: cover; width: 100%; height: 200px;">
                         </a>
                         <p class="card-text text-dark flex-grow-1">
-                            Andrew Ligeralde from Phare Bio presents on the modelling and generative design strategies used at Phare Bio to develop the next generation of antibiotics.
+                            {{ .summary }}
                         </p>
-                        <a href="https://www.youtube.com/watch?v=c_MhLscr9Lw" class="btn btn-openadmet mt-auto align-self-start" target="_blank">
+                        <a href="{{ .url }}" class="btn btn-openadmet mt-auto align-self-start" target="_blank">
                             Watch &rarr;
                         </a>
                     </div>
                 </div>
             </div>
-
-            <div class="col-md-6 col-xl-4">
-                <div class="card h-100 border-0 shadow-sm rounded-4">
-                    <div class="card-body d-flex flex-column p-4">
-                        <div class="text-muted small mb-2">April 13, 2026</div>
-                        <h5 class="card-title fw-bold mb-3">Srijit Seal, University of Cambridge — Making Machine Learning Successful in Drug Discovery</h5>
-                        <a href="https://www.youtube.com/watch?v=xgTpLLonvh4" target="_blank">
-                            <img src="https://img.youtube.com/vi/xgTpLLonvh4/hqdefault.jpg" class="img-fluid rounded-3 mb-3" alt="Srijit Seal thumbnail" style="object-fit: cover; width: 100%; height: 200px;">
-                        </a>
-                        <p class="card-text text-dark flex-grow-1">
-                            Srijit Seal presents on the pillars of making machine learning successful in drug discovery, as well as some recent results from blind challenges run by OpenADMET.
-                        </p>
-                        <a href="https://www.youtube.com/watch?v=xgTpLLonvh4" class="btn btn-openadmet mt-auto align-self-start" target="_blank">
-                            Watch &rarr;
-                        </a>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-6 col-xl-4">
-                <div class="card h-100 border-0 shadow-sm rounded-4">
-                    <div class="card-body d-flex flex-column p-4">
-                        <div class="text-muted small mb-2">March 18, 2026</div>
-                        <h5 class="card-title fw-bold mb-3">Applying a Focused Modeling Strategy in the OpenADMET ExpansionRx Blind Challenge</h5>
-                        <a href="https://www.youtube.com/watch?v=eXE2zz0uQyo" target="_blank">
-                            <img src="https://img.youtube.com/vi/eXE2zz0uQyo/hqdefault.jpg" class="img-fluid rounded-3 mb-3" alt="ExpansionRx Focused Modeling thumbnail" style="object-fit: cover; width: 100%; height: 200px;">
-                        </a>
-                        <p class="card-text text-dark flex-grow-1">
-                            A CDD webinar with Alex Rich from Inductive Bio and Daniel Crusius from deepmirror, top performers in the ExpansionRx Blind Challenge, presenting their focused modeling strategy.
-                        </p>
-                        <a href="https://www.youtube.com/watch?v=eXE2zz0uQyo" class="btn btn-openadmet mt-auto align-self-start" target="_blank">
-                            Watch &rarr;
-                        </a>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-6 col-xl-4">
-                <div class="card h-100 border-0 shadow-sm rounded-4">
-                    <div class="card-body d-flex flex-column p-4">
-                        <div class="text-muted small mb-2">March 9, 2026</div>
-                        <h5 class="card-title fw-bold mb-3">Applying Real-World Drug Discovery Experience in the OpenADMET ExpansionRx Blind Challenge</h5>
-                        <a href="https://www.youtube.com/watch?v=ukcIjqdzVnA" target="_blank">
-                            <img src="https://img.youtube.com/vi/ukcIjqdzVnA/hqdefault.jpg" class="img-fluid rounded-3 mb-3" alt="ExpansionRx Real-World Experience thumbnail" style="object-fit: cover; width: 100%; height: 200px;">
-                        </a>
-                        <p class="card-text text-dark flex-grow-1">
-                            A CDD webinar with Jason Wang from Merck &amp; Co and Davide Boldini from EMD Serono/Merck KGaA, discussing their approach in the ExpansionRx Blind Challenge.
-                        </p>
-                        <a href="https://www.youtube.com/watch?v=ukcIjqdzVnA" class="btn btn-openadmet mt-auto align-self-start" target="_blank">
-                            Watch &rarr;
-                        </a>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-6 col-xl-4">
-                <div class="card h-100 border-0 shadow-sm rounded-4">
-                    <div class="card-body d-flex flex-column p-4">
-                        <div class="text-muted small mb-2">February 19, 2026</div>
-                        <h5 class="card-title fw-bold mb-3">Ruel Cedeno, Novalix — OpenADMET Science Seminar</h5>
-                        <a href="https://www.youtube.com/watch?v=uIjUHksd-GM" target="_blank">
-                            <img src="https://img.youtube.com/vi/uIjUHksd-GM/hqdefault.jpg" class="img-fluid rounded-3 mb-3" alt="Ruel Cedeno thumbnail" style="object-fit: cover; width: 100%; height: 200px;">
-                        </a>
-                        <p class="card-text text-dark flex-grow-1">
-                            OpenADMET Science Seminar presentation by Ruel Cedeno from Novalix.
-                        </p>
-                        <a href="https://www.youtube.com/watch?v=uIjUHksd-GM" class="btn btn-openadmet mt-auto align-self-start" target="_blank">
-                            Watch &rarr;
-                        </a>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-6 col-xl-4">
-                <div class="card h-100 border-0 shadow-sm rounded-4">
-                    <div class="card-body d-flex flex-column p-4">
-                        <div class="text-muted small mb-2">January 19, 2026</div>
-                        <h5 class="card-title fw-bold mb-3">Jackson Burns, MIT — OpenADMET Science Seminar</h5>
-                        <a href="https://www.youtube.com/watch?v=Rmi_TGM8L-0" target="_blank">
-                            <img src="https://img.youtube.com/vi/Rmi_TGM8L-0/hqdefault.jpg" class="img-fluid rounded-3 mb-3" alt="Jackson Burns thumbnail" style="object-fit: cover; width: 100%; height: 200px;">
-                        </a>
-                        <p class="card-text text-dark flex-grow-1">
-                            Jackson Burns of the Green Lab at MIT presents on the CheMeleon foundation model for molecular property prediction.
-                        </p>
-                        <a href="https://www.youtube.com/watch?v=Rmi_TGM8L-0" class="btn btn-openadmet mt-auto align-self-start" target="_blank">
-                            Watch &rarr;
-                        </a>
-                    </div>
-                </div>
-            </div>
+            {{ end }}
         </div>
 
         <div class="text-center mt-5">
-            <a href="https://www.youtube.com/@OpenADMET" class="btn btn-openadmet btn-lg px-4" target="_blank">
+            <a href="{{ site.Params.youtubeChannel }}" class="btn btn-openadmet btn-lg px-4" target="_blank">
                 View All Videos
             </a>
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -219,32 +219,35 @@
                 </div>
             </div>
 
+            {{ $post := partial "feeds/ghost-latest.html" . }}
             <div class="col-lg-3 col-md-6 d-flex">
                 <div class="card border-0 shadow-sm w-100 d-flex flex-column overflow-hidden" style="border-radius: 1rem;">
                     <div class="section-card-header">
                         <h3>Blog</h3>
                     </div>
                     <div class="card-body p-4 flex-grow-1">
-                        <div class="text-muted small mb-1">July 3, 2026</div>
-                        <h5 class="fw-bold mb-2">It's the End of the PXR Challenge as We Know It (and I feel fine)</h5>
+                        <div class="text-muted small mb-1">{{ $post.date }}</div>
+                        <h5 class="fw-bold mb-2">{{ $post.title }}</h5>
                         <p class="text-dark mb-0">
-                            Announcing the results of the PXR Blind Challenge, which released the largest high-quality dataset of PXR induction ever made publicly available, with over 11,000 compounds.
+                            {{ $post.summary }}
                         </p>
                     </div>
                     <div class="card-footer bg-white border-0 p-4 pt-0">
-                        <a href="https://openadmet.ghost.io/its-the-end-of-the-pxr-challenge-as-we-know-it-and-i-feel-fine/" class="btn btn-openadmet">More &rarr;</a>
+                        <a href="{{ $post.url }}" class="btn btn-openadmet">More &rarr;</a>
                     </div>
                 </div>
             </div>
 
+            {{/* range over the newest one: renders nothing rather than erroring if the feed is empty */}}
+            {{ range first 1 (partial "feeds/youtube-videos.html" .) }}
             <div class="col-lg-3 col-md-6 d-flex">
                 <div class="card border-0 shadow-sm w-100 d-flex flex-column overflow-hidden" style="border-radius: 1rem;">
                     <div class="section-card-header">
                         <h3>Videos</h3>
                     </div>
                     <div class="card-body p-4 flex-grow-1">
-                        <div class="text-muted small mb-1">April 29, 2026</div>
-                        <h5 class="fw-bold mb-2">Andrew Ligeralde, PhareBio — QSAR Modeling for Property Prediction and Generative Design</h5>
+                        <div class="text-muted small mb-1">{{ .date }}</div>
+                        <h5 class="fw-bold mb-2">{{ .title }}</h5>
                         <p class="text-dark mb-0">
                             Science seminars, challenge webinars, and workshop recordings from the OpenADMET community.
                         </p>
@@ -254,6 +257,7 @@
                     </div>
                 </div>
             </div>
+            {{ end }}
 
             <div class="col-lg-3 col-md-6 d-flex">
                 <div class="card border-0 shadow-sm w-100 d-flex flex-column overflow-hidden" style="border-radius: 1rem;">

--- a/layouts/partials/feeds/ghost-latest.html
+++ b/layouts/partials/feeds/ghost-latest.html
@@ -1,0 +1,38 @@
+{{/*
+  Returns the most recent Ghost post as a dict: title, url, date, summary.
+
+  The summary comes from the post's Excerpt field in the Ghost editor. If no
+  excerpt is set, Ghost falls back to the opening sentences of the post, which
+  reads poorly on a card — so set the Excerpt when publishing.
+
+  If the feed is unreachable the fallback below is used and the build continues,
+  leaving the card showing its last known content rather than an empty box.
+*/}}
+
+{{ $post := dict
+  "title" "It’s the End of the PXR Challenge as We Know It (and I feel fine)"
+  "url" "https://openadmet.ghost.io/its-the-end-of-the-pxr-challenge-as-we-know-it-and-i-feel-fine/"
+  "date" "July 3, 2026"
+  "summary" "Announcing the results of the PXR Blind Challenge, which released the largest high-quality dataset of PXR induction ever made publicly available, with over 11,000 compounds."
+}}
+
+{{ with try (resources.GetRemote site.Params.ghostFeed) }}
+  {{ with .Err }}
+    {{ warnf "Ghost feed unreachable (%s) — homepage Blog card is using fallback content." . }}
+  {{ else with .Value }}
+    {{ $items := (. | transform.Unmarshal).channel.item }}
+    {{ with $items }}
+      {{ $item := cond (reflect.IsSlice $items) (index $items 0) $items }}
+      {{ $post = dict
+        "title" $item.title
+        "url" $item.link
+        "date" ((time.AsTime $item.pubDate).Format "January 2, 2006")
+        "summary" ($item.description | plainify | strings.ReplaceRE `\s+` " " | strings.TrimSpace | truncate 200)
+      }}
+    {{ else }}
+      {{ warnf "Ghost feed returned no posts — homepage Blog card is using fallback content." }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return $post }}

--- a/layouts/partials/feeds/ghost-latest.html
+++ b/layouts/partials/feeds/ghost-latest.html
@@ -6,14 +6,16 @@
   reads poorly on a card — so set the Excerpt when publishing.
 
   If the feed is unreachable the fallback below is used and the build continues,
-  leaving the card showing its last known content rather than an empty box.
+  showing a generic evergreen blog card rather than an empty box. It is
+  deliberately dateless and post-agnostic so it never goes stale, no matter when
+  an outage happens. ("date" here is repurposed as a kicker label.)
 */}}
 
 {{ $post := dict
-  "title" "It’s the End of the PXR Challenge as We Know It (and I feel fine)"
-  "url" "https://openadmet.ghost.io/its-the-end-of-the-pxr-challenge-as-we-know-it-and-i-feel-fine/"
-  "date" "July 3, 2026"
-  "summary" "Announcing the results of the PXR Blind Challenge, which released the largest high-quality dataset of PXR induction ever made publicly available, with over 11,000 compounds."
+  "title" "Insights from the OpenADMET team"
+  "url" "https://openadmet.ghost.io/"
+  "date" "OpenADMET Blog"
+  "summary" "Deep dives on open ADMET data, blind-challenge results, and predictive modeling. Read the latest on our blog."
 }}
 
 {{ with try (resources.GetRemote site.Params.ghostFeed) }}

--- a/layouts/partials/feeds/youtube-videos.html
+++ b/layouts/partials/feeds/youtube-videos.html
@@ -1,0 +1,56 @@
+{{/*
+  Returns the channel's uploads, newest first, as a slice of dicts:
+  id, title, url, date, summary, thumb.
+
+  The card copy is the video's YouTube description, so that description is the
+  single place to edit it — the site follows whatever is on the video.
+
+  Dates render in UTC, as published by the feed. A video uploaded late in the
+  Pacific evening therefore shows the following day's date. Hugo cannot convert
+  to a fixed zone here: the site timeZone setting is ignored once the timestamp
+  carries an offset, and .Local would follow the build machine, making local and
+  CI builds disagree.
+
+  Returns an empty slice if the feed is unreachable. Callers decide what that
+  means for them; /videos treats it as a build error so a broken feed can never
+  publish an empty gallery over a working one.
+*/}}
+
+{{ $videos := slice }}
+
+{{ with try (resources.GetRemote site.Params.youtubeFeed) }}
+  {{ with .Err }}
+    {{ warnf "YouTube feed unreachable: %s" . }}
+  {{ else with .Value }}
+    {{ $entries := (. | transform.Unmarshal).entry }}
+    {{ with $entries }}
+      {{ range (cond (reflect.IsSlice $entries) $entries (slice $entries)) }}
+        {{/* Match the site's typography: collapse stray spaces, hyphen to em dash. */}}
+        {{ $title := .title | strings.ReplaceRE `\s+` " " | strings.ReplaceRE ` - ` " — " | strings.TrimSpace }}
+        {{/* Long descriptions often carry a timestamp index or link list; keep the lead paragraph only. */}}
+        {{ $summary := "" }}
+        {{ with .group }}
+          {{ $summary = .description | plainify | strings.TrimSpace }}
+          {{ $summary = index (split $summary "\n\n") 0 }}
+          {{ $summary = $summary | strings.ReplaceRE `\s+` " " | strings.TrimSpace | truncate 220 }}
+        {{ end }}
+        {{ if not $summary }}
+          {{ warnf "YouTube video %q has no description, so its card falls back to generic text. Add a description on YouTube to fix it." $title }}
+          {{ $summary = "A recording from the OpenADMET community." }}
+        {{ end }}
+        {{ $videos = $videos | append (dict
+          "id" .videoId
+          "title" $title
+          "url" (printf "https://www.youtube.com/watch?v=%s" .videoId)
+          "thumb" (printf "https://img.youtube.com/vi/%s/hqdefault.jpg" .videoId)
+          "date" ((time.AsTime .published).Format "January 2, 2006")
+          "published" .published
+          "summary" $summary
+        ) }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{/* published is ISO 8601, so a string sort is chronological. */}}
+{{ return (sort $videos "published" "desc") }}


### PR DESCRIPTION
The homepage Blog card, homepage Videos card, and the /videos gallery were hardcoded HTML that had to be hand-edited for every new post or video, and had drifted out of date (the newest video was missing from the site).

Fetch this content at build time instead:
- Blog card  <- Ghost RSS (openadmet.ghost.io/rss)
- Videos card + /videos gallery <- YouTube channel RSS

New partials layouts/partials/feeds/{ghost-latest,youtube-videos}.html return the parsed feed data; the templates render from them. Feed URLs live in [params] in config.toml. The existing nightly build cron now refreshes the cards automatically, so no HTML edits are needed going forward.

Card copy is sourced from the Ghost Excerpt field and the YouTube video description respectively, so those become the single place to edit each card.

Failure handling: a YouTube outage fails the build (errorf) so the deploy is skipped and the live gallery is left intact rather than replaced by an empty one; a Ghost outage degrades to a baked-in fallback post.

README documents the mechanism, how to control card copy, and the known UTC-date / 15-video-feed-limit behaviors.